### PR TITLE
removed titleize

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -602,7 +602,7 @@ class Question < ActiveRecord::Base
 
         if !assignee
           assignee = pick_user_from_list(group_assignees.active.route_from_anywhere)
-          reason_assigned = "You chose to accept questions from #{group.name.titleize} Group"
+          reason_assigned = "You chose to accept questions from #{group.name} group"
         end
         # still aint got no one? assign to a group leader
         if !assignee


### PR DESCRIPTION
Removed titleize and also change Group to group (lowercase). titleize was an attempt to get more consistency in display of group names. While it improved readability of some names, it made the name less readable for others.