### PR TITLE
Assignment algorithm tweak

### DIFF
--- a/app/assets/stylesheets/all/groups.css.scss
+++ b/app/assets/stylesheets/all/groups.css.scss
@@ -25,3 +25,4 @@
 .simple-code {color:#000; background:#fff;}
 .widget_example {width:200px !important;}
 .widget_example-wrapper {padding:1em; background:#fff; display:block;}
+.group-member-warning {background: #FFFFA3; padding:2px 5px; display:block;}

--- a/app/assets/stylesheets/all/groups.css.scss
+++ b/app/assets/stylesheets/all/groups.css.scss
@@ -26,3 +26,9 @@
 .widget_example {width:200px !important;}
 .widget_example-wrapper {padding:1em; background:#fff; display:block;}
 .group-member-warning {background: #FFFFA3; padding:2px 5px; display:block;}
+.member-away td {background: #eee !important;}
+.member-away td {color: #888 !important;}
+.member-away .handling_rate {color: #888 !important;}
+.member-away .group-member-warning {background: #f5f5f5 !important;}
+
+.member-away .handling_rate_graph .graph {background: #bbb !important;}

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -595,7 +595,7 @@ class Question < ActiveRecord::Base
       if group_assignees.length > 0
         if (group.ignore_county_routing == true) && self.location.present?
           assignee = pick_user_from_list(group_assignees.with_expertise_location(self.location.id))
-          reason_assigned = "You chose to accept questions based on location (#{self.location.name})"
+          reason_assigned = "The question location (#{self.location.name}) matched the member's expertise location. Note: This group ignores counties when automatically assigning questions."
         else
           if self.county.present?
             assignee = pick_user_from_list(group_assignees.with_expertise_county(self.county.id))
@@ -637,7 +637,7 @@ class Question < ActiveRecord::Base
       # send to the question wrangler group if the location of the question is not in the location of the group and
       # the group is not receiving questions from outside their defined locations.
       assignee = pick_user_from_list(Group.get_wrangler_assignees(self.location, self.county, assignees_to_exclude))
-      reason_assigned = "You are a Question Wrangler"
+      reason_assigned = "This question's location did not match the group's location so it was assigned to a Question Wrangler"
     end
 
     if assignee
@@ -874,20 +874,14 @@ class Question < ActiveRecord::Base
 
     # who all matches the least amt. of questions assigned
     possible_users = users.select { |u| u.open_questions.length == questions_floor }
-    # p "possible_users default order:"
-    # possible_users.each {|e| puts e.id }
 
     return nil if !possible_users or possible_users.length == 0
     return possible_users[0] if possible_users.length == 1
 
-    possible_users.sort! { |a, b| a.last_question_touched <=> b.last_question_touched }
-    # p "possible_users sorted by last touched:"
-    # possible_users.each {|e| puts e.login, e.id }
-
     # if all possible question assignees with least amt. of questions assigned have zero questions assigned to them...
     # so if all experts that made the cut have zero questions assigned, pick a random person in that group to assign to
     if questions_floor == 0
-      # return possible_users.sample
+      possible_users.sort! { |a, b| a.last_question_touched <=> b.last_question_touched }
       return possible_users.first
     end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -870,17 +870,25 @@ class Question < ActiveRecord::Base
     users.sort! { |a, b| a.open_questions.length <=> b.open_questions.length }
 
     questions_floor = users[0].open_questions.length
+    # p "questions_floor: #{questions_floor}"
 
     # who all matches the least amt. of questions assigned
     possible_users = users.select { |u| u.open_questions.length == questions_floor }
+    # p "possible_users default order:"
+    # possible_users.each {|e| puts e.id }
 
     return nil if !possible_users or possible_users.length == 0
     return possible_users[0] if possible_users.length == 1
 
+    possible_users.sort! { |a, b| a.last_question_touched <=> b.last_question_touched }
+    # p "possible_users sorted by last touched:"
+    # possible_users.each {|e| puts e.login, e.id }
+
     # if all possible question assignees with least amt. of questions assigned have zero questions assigned to them...
     # so if all experts that made the cut have zero questions assigned, pick a random person in that group to assign to
     if questions_floor == 0
-      return possible_users.sample
+      # return possible_users.sample
+      return possible_users.first
     end
 
     assignment_dates = Hash.new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -477,6 +477,15 @@ class User < ActiveRecord::Base
     end
   end
 
+  def last_question_touched
+    last_touched = self.initiated_question_events.order('created_at DESC').pluck(:created_at).first
+    if(!last_touched.blank?)
+      last_touched
+    else
+      nil
+    end
+  end
+
   def daily_summary_group_list
     list = []
     self.group_memberships.each{|group| list.push(group) if (send_daily_summary?(group) and group.include_in_daily_summary?)}

--- a/app/views/expert/groups/members.html.erb
+++ b/app/views/expert/groups/members.html.erb
@@ -37,7 +37,7 @@
   <tbody>
 
 <% @group_members.each do |member| %>
-  <tr>
+  <tr class="<%= member.away? ? "member-away" : "" %>">
       <td>
         <%= link_expert_user_avatar(member, :thumb) %> <%= link_expert_user(member) %>
         <% if member.leader_of_group(@group)%><strong><i class="icon-user"></i> Leader</strong><% end %>

--- a/app/views/expert/groups/members.html.erb
+++ b/app/views/expert/groups/members.html.erb
@@ -24,6 +24,7 @@
       <th>Name</th>
       <th>Primary Location</th>
       <th>Accepts Questions from</th>
+      <th>Auto-assignments</th>
       <th>Handling Rate</th>
       <th>Last Active</th>
       <th>Last touched a question</th>
@@ -57,6 +58,7 @@
         States only
         <% end %>
       </td>
+      <td><%= member.auto_route? ? "Accepts automatic assignments" : "Doesn't accept automatic assignments" %></td>
       <td><p class="handling_rate"><%= display_handling_rate(@handling_rates[member.id]) %> <%= display_handling_rate_bar(@handling_rates[member.id]) %></p></td>
       <td><span class="downplay">last active <%= get_last_active_time(member) %></span></td>
       <td><span class="downplay"><%= !member.last_question_touched.blank? ? "#{time_ago_in_words(member.last_question_touched)} ago" : "No handling activity" %></td>

--- a/app/views/expert/groups/members.html.erb
+++ b/app/views/expert/groups/members.html.erb
@@ -3,7 +3,7 @@
 <div class="explanation">
   <h2>What Are Group Leaders?</h2>
   <p>Group leadership is a self-serve option. Anyone can choose to take a more active role in a group by becoming a leader.</p>
-  
+
   <ul>
     <li>Leaders are identified as a point person for a group.</li>
     <li>Leaders receive notifications when a member or leader joins or leaves.</li>
@@ -13,7 +13,7 @@
   <div id="leadership_options">
     <%= render :partial => 'leadership_options' %>
   </div>
-  
+
 </div>
 
 <p><%= link_to 'CSV Email Download', email_csv_expert_group_path(@group, format: "csv") %></p>
@@ -26,28 +26,29 @@
       <th>Accepts Questions from</th>
       <th>Handling Rate</th>
       <th>Last Active</th>
+      <th>Last touched a question</th>
       <th>Notified on every question</th>
       <th>Receives daily summary</th>
     </tr>
   </thead>
   <tbody>
-  
+
 <% @group_members.each do |member| %>
   <tr>
       <td>
-        <%= link_expert_user_avatar(member, :thumb) %> <%= link_expert_user(member) %> 
+        <%= link_expert_user_avatar(member, :thumb) %> <%= link_expert_user(member) %>
         <% if member.leader_of_group(@group)%><strong><i class="icon-user"></i> Leader</strong><% end %>
       </td>
       <td>
         <% if member.location %>
           <% if member.county %>
-            <%= member.county.name %>, 
+            <%= member.county.name %>,
           <% end %>
           <%= member.location.abbreviation %>
         <% end %>
       </td>
       <td>
-        <% case member.routing_instructions 
+        <% case member.routing_instructions
            when "anywhere" %>
         Anywhere
         <% when "counties_only" %>
@@ -58,6 +59,7 @@
       </td>
       <td><p class="handling_rate"><%= display_handling_rate(@handling_rates[member.id]) %> <%= display_handling_rate_bar(@handling_rates[member.id]) %></p></td>
       <td><span class="downplay">last active <%= get_last_active_time(member) %></span></td>
+      <td><span class="downplay"><%= !member.last_question_touched.blank? ? "#{time_ago_in_words(member.last_question_touched)} ago" : "No handling activity" %></td>
       <td><% if member.send_incoming_notification?(@group) %>Notified on every question<% end %></td>
       <td><% if member.send_daily_summary?(@group) %>Receives daily summary<% end %></td>
   </tr>

--- a/app/views/expert/groups/members.html.erb
+++ b/app/views/expert/groups/members.html.erb
@@ -24,7 +24,9 @@
       <th>Name</th>
       <th>Primary Location</th>
       <th>Accepts Questions from</th>
-      <th>Auto-assignments</th>
+      <%- if @group.individual_assignment -%>
+        <th>Auto-assignments</th>
+      <%- end -%>
       <th>Handling Rate</th>
       <th>Last Active</th>
       <th>Last touched a question</th>
@@ -58,7 +60,21 @@
         States only
         <% end %>
       </td>
-      <td><%= member.auto_route? ? "Accepts automatic assignments" : "Doesn't accept automatic assignments" %></td>
+      <%- if @group.individual_assignment -%>
+      <td>
+        <%- if member.auto_route? %>
+          Accepts automatic assignments
+        <%- else -%>
+          <span class="group-member-warning">This group cannot automatically assign questions to this person because <strong>they don't accept automatic assignments</strong>.</span>
+        <%- end -%>
+
+        <%- if member.auto_route? && !@group.assignment_outside_locations -%>
+          <%- if (member.expertise_locations & @group.expertise_locations).empty? %>
+            <p><span class="group-member-warning">This group cannot automatically assign questions to this person because <strong>their expertise locations don't match this group's expertise locations</strong>.</span></p>
+          <%- end -%>
+        <%- end -%>
+      </td>
+      <%- end -%>
       <td><p class="handling_rate"><%= display_handling_rate(@handling_rates[member.id]) %> <%= display_handling_rate_bar(@handling_rates[member.id]) %></p></td>
       <td><span class="downplay">last active <%= get_last_active_time(member) %></span></td>
       <td><span class="downplay"><%= !member.last_question_touched.blank? ? "#{time_ago_in_words(member.last_question_touched)} ago" : "No handling activity" %></td>


### PR DESCRIPTION
Groups have reported the same expert was receiving serial question assignments while others in the group were never being assigned. The following changes were made to try to address the unexpected assignment behavior.

* The following change was made to the routing algorithm: Within a pool of experts with equal (or zero) assignments, assign to the person who touched a question the longest ago instead of randomly selecting a person.
* Provide more transparency for group leaders on the membership list page so they can see the actual pool of available assignees.
* On the list page, indicate when members cannot be assigned questions because of mismatched expertise tags or when members have auto-assignments turned off.
* Provide more granular explanations for the logic behind question assignments in the question history.