### PR TITLE
Change scope for notification of individual questions to a group

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,6 +373,3 @@ DEPENDENCIES
   turn
   uglifier (>= 1.0.3)
   useragent
-
-BUNDLED WITH
-   1.10.3

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -22,6 +22,7 @@ class Group < ActiveRecord::Base
   has_many :members, :through => :group_connections, :source => :user, :conditions => "group_connections.connection_type = 'member' and users.retired = 0"
   has_many :leaders, :through => :group_connections, :source => :user, :conditions => "group_connections.connection_type = 'leader' and users.retired = 0"
   has_many :assignees, :through => :group_connections, :source => :user, :conditions => "(group_connections.connection_type = 'member' OR group_connections.connection_type = 'leader') and users.retired = 0 and users.away = 0 and users.auto_route = 1"
+  has_many :active_connections, :through => :group_connections, :source => :user, :conditions => "(group_connections.connection_type = 'member' OR group_connections.connection_type = 'leader') and users.retired = 0 and users.away = 0"
   # these are not relevant right now, but we might use some of this in the future
   # has_many :invited, :through => :group_connections, :source => :user, :conditions => "group_connections.connection_type = 'invited' and users.retired = 0"
   # has_many :interest, :through => :group_connections, :source => :user, :conditions => "group_connections.connection_type = 'interest' and users.retired = 0"
@@ -190,7 +191,7 @@ class Group < ActiveRecord::Base
 
   def incoming_notification_list(users_to_exclude=[])
     list = []
-    self.assignees.each{|assignee| list.push(assignee) if assignee.send_incoming_notification?(self.id)}
+    self.active_connections.each{|assignee| list.push(assignee) if assignee.send_incoming_notification?(self.id)}
     if !users_to_exclude.nil?
       list = list - users_to_exclude
     end


### PR DESCRIPTION
* the existing scope excluded group members who had Automatic assignments turned off. This has been changed to allow those members to receive notifications even if they have automatic assignments turned off.